### PR TITLE
feat: add PostToolUse hook to enforce post-deploy monitoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Install: `npx skills add truefoundry/tfy-deploy-skills --all`
 
 | Task | Command |
 |------|---------|
-| Lint shell scripts | `shellcheck scripts/*.sh hooks/auto-approve-tfy-api.sh skills/_shared/scripts/tfy-api.sh` |
+| Lint shell scripts | `shellcheck scripts/*.sh hooks/auto-approve-tfy-api.sh hooks/post-deploy-monitor.sh skills/_shared/scripts/tfy-api.sh` |
 | Lint skill scripts | `find skills -mindepth 2 -name '*.sh' -print0 \| xargs -0 -r shellcheck` |
 | Validate skills | `./scripts/validate-skills.sh` |
 | Security checks | `./scripts/validate-skill-security.sh` |

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Auto-approve TrueFoundry API calls",
+  "description": "TrueFoundry skill hooks: auto-approve API calls and enforce post-deploy monitoring",
   "hooks": {
     "PreToolUse": [
       {
@@ -8,6 +8,17 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/auto-approve-tfy-api.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/post-deploy-monitor.sh"
           }
         ]
       }

--- a/hooks/post-deploy-monitor.sh
+++ b/hooks/post-deploy-monitor.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# PostToolUse hook: After a successful tfy apply/deploy, remind the agent to monitor.
+# Reads tool result from stdin (JSON with tool_input.command and tool_result fields).
+# Outputs a reminder message to stdout that the agent will see.
+
+set -e
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+EXIT_CODE=$(echo "$INPUT" | jq -r '.tool_result.exitCode // empty' 2>/dev/null || true)
+
+# Only act on successful tfy apply or tfy deploy commands
+if [[ "$EXIT_CODE" != "0" ]]; then
+  exit 0
+fi
+
+# Match tfy apply or tfy deploy (with optional flags)
+# shellcheck disable=SC2016
+_RE_APPLY='^[[:space:]]*(tfy[[:space:]]+apply|tfy[[:space:]]+deploy)[[:space:]]'
+if [[ "$COMMAND" =~ $_RE_APPLY ]]; then
+  cat <<'EOF'
+MANDATORY POST-DEPLOY ACTION: A deployment command just completed successfully.
+You MUST now monitor the deployment to a terminal state. Do NOT end your response.
+Do NOT ask the user "should I monitor?" — start polling immediately.
+
+Poll the deployment status using:
+  bash $TFY_API_SH GET '/api/svc/v1/apps?workspaceFqn=WORKSPACE_FQN&applicationName=APP_NAME'
+
+Keep polling every 15-30s until state.isTerminalState is true.
+On success: report replicas, endpoint URL, run health check.
+On failure: fetch logs, diagnose, suggest fix.
+EOF
+  exit 0
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Adds a `PostToolUse` hook (`hooks/post-deploy-monitor.sh`) that detects successful `tfy apply` / `tfy deploy` commands and injects a mandatory reminder for the agent to poll deployment status to a terminal state
- Registers the hook in `hooks/hooks.json` alongside the existing PreToolUse auto-approve hook
- Updates CLAUDE.md shellcheck command to include the new hook script

## Why
Agents weren't consistently monitoring deployments after deploy commands despite HARD RULE instructions in the deploy skill. Instructions alone aren't enough — the agent can "forget" mid-response. Hooks fire at the system level after each tool call, making it much harder to skip monitoring.

## Test plan
- [x] Hook fires on successful `tfy apply` — outputs reminder
- [x] Hook fires on successful `tfy deploy` — outputs reminder
- [x] Hook is silent on failed deploy (exit code != 0)
- [x] Hook is silent on unrelated commands
- [x] shellcheck passes
- [x] Unit tests pass (`./scripts/test-tfy-api.sh`)
- [x] Skill validation passes (`./scripts/validate-skills.sh`)
- [x] Security checks pass (`./scripts/validate-skill-security.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Claude hook script and wiring that only emits a reminder message after successful `tfy apply`/`tfy deploy` Bash commands, without changing deployment logic or making API calls.
> 
> **Overview**
> Adds a new `PostToolUse` Bash hook (`hooks/post-deploy-monitor.sh`) that detects successful `tfy apply`/`tfy deploy` executions and prints a mandatory reminder instructing the agent to poll deployment status to a terminal state.
> 
> Registers this hook in `hooks/hooks.json` alongside the existing pre-tool auto-approval hook, and updates `CLAUDE.md` lint instructions to include shellchecking the new script.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b214db6754f0ae378099e04f8ba88e2f8afaf77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->