### PR TITLE
claude/complete-pr-12-RL4gM

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -50,7 +50,7 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/plugin-scripts/post-deploy-monitor.sh\"",
-            "timeout": 1800
+            "timeout": 3600
           }
         ]
       }

--- a/plugin-scripts/post-deploy-monitor.sh
+++ b/plugin-scripts/post-deploy-monitor.sh
@@ -24,6 +24,9 @@ if [[ "$COMMAND" =~ tfy[[:space:]]+(apply|deploy)[[:space:]]+-f[[:space:]]+([^[:
   # Try to extract app name from the manifest file
   if [[ -f "$manifest_file" ]]; then
     app_name=$(grep -m1 '^name:' "$manifest_file" 2>/dev/null | sed 's/^name:[[:space:]]*//' || true)
+    # Strip surrounding YAML quotes (e.g., name: "my-app" -> my-app)
+    app_name="${app_name#\"}" && app_name="${app_name%\"}"
+    app_name="${app_name#\'}" && app_name="${app_name%\'}"
   fi
 elif [[ "$COMMAND" =~ tfy[[:space:]]+(apply|deploy)([[:space:]]|$) ]]; then
   # tfy deploy / tfy apply without -f (working directory deploy)
@@ -33,6 +36,9 @@ elif [[ "$COMMAND" =~ tfy[[:space:]]+(apply|deploy)([[:space:]]|$) ]]; then
     if [[ -f "$candidate" ]]; then
       manifest_file="$candidate"
       app_name=$(grep -m1 '^name:' "$candidate" 2>/dev/null | sed 's/^name:[[:space:]]*//' || true)
+      # Strip surrounding YAML quotes (e.g., name: "my-app" -> my-app)
+      app_name="${app_name#\"}" && app_name="${app_name%\"}"
+      app_name="${app_name#\'}" && app_name="${app_name%\'}"
       break
     fi
   done
@@ -71,6 +77,11 @@ if [[ -f ".env" ]]; then
     fi
   done < .env
 fi
+
+# Bridge Claude plugin userConfig values (same pattern as session-start.sh)
+# Each hook runs in a separate shell process, so session-start.sh exports don't persist.
+TFY_BASE_URL="${TFY_BASE_URL:-${CLAUDE_PLUGIN_OPTION_TFY_BASE_URL:-}}"
+TFY_API_KEY="${TFY_API_KEY:-${CLAUDE_PLUGIN_OPTION_TFY_API_KEY:-}}"
 
 TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
 BASE="${TFY_BASE_URL%/}"
@@ -123,7 +134,8 @@ fi
 SESSION_KEY="${CLAUDE_SESSION_ID:-${PPID:-$$}}"
 STATE_DIR=$(cat "${TMPDIR:-/tmp}/tfy-plugin-state-${SESSION_KEY}" 2>/dev/null || echo "")
 if [[ -n "$STATE_DIR" && -d "$STATE_DIR" ]]; then
-  echo "{\"app\":\"$app_name\",\"workspace\":\"$workspace_fqn\",\"ts\":$(date +%s)}" >> "$STATE_DIR/deployments.jsonl"
+  jq -n --arg app "$app_name" --arg workspace "$workspace_fqn" --argjson ts "$(date +%s)" \
+    '{"app":$app,"workspace":$workspace,"ts":$ts}' >> "$STATE_DIR/deployments.jsonl"
 fi
 
 # --- Poll deployment status ---
@@ -355,5 +367,13 @@ fi
 
 # Update state file with final status
 if [[ -n "$STATE_DIR" && -d "$STATE_DIR" ]]; then
-  echo "{\"app\":\"$app_name\",\"workspace\":\"$workspace_fqn\",\"status\":\"$final_status\",\"endpoint\":\"$endpoint_url\",\"model\":\"${model_id:-}\",\"ts\":$(date +%s)}" > "$STATE_DIR/last-deploy.json"
+  jq -n \
+    --arg app "$app_name" \
+    --arg workspace "$workspace_fqn" \
+    --arg status "$final_status" \
+    --arg endpoint "$endpoint_url" \
+    --arg model "${model_id:-}" \
+    --argjson ts "$(date +%s)" \
+    '{"app":$app,"workspace":$workspace,"status":$status,"endpoint":$endpoint,"model":$model,"ts":$ts}' \
+    > "$STATE_DIR/last-deploy.json"
 fi

--- a/plugin-scripts/pre-tool-secret-scan.sh
+++ b/plugin-scripts/pre-tool-secret-scan.sh
@@ -16,9 +16,11 @@ if [[ -z "$COMMAND" ]]; then
 fi
 
 # Only scan commands that could contain deploy manifests or API calls
-# Skip simple read-only commands
+# Skip simple read-only commands — but NOT if they chain into a deploy (e.g., cat <<EOF ... && tfy apply)
 if [[ "$COMMAND" =~ ^[[:space:]]*(ls|cat|head|tail|grep|find|echo|pwd|cd|which|tfy[[:space:]]--version) ]]; then
-  exit 2
+  if ! echo "$COMMAND" | grep -qE '(tfy[[:space:]]+(apply|deploy)|/api/svc/v1/apps)'; then
+    exit 2
+  fi
 fi
 
 # --- Pattern matching for likely hardcoded secrets ---


### PR DESCRIPTION
- hooks/hooks.json: raise PostToolUse timeout from 1800s to 3600s to
  cover worst-case monitor runtime (60 polls × 60s = 3600s for LLM
  deploys), preventing the stop-review-gate from treating valid slow
  deployments as incomplete (Thread 12)

- pre-tool-secret-scan.sh: fix allowlist bypass for piped deploy
  commands (e.g. cat <<EOF...secret...EOF && tfy apply). The early
  exit-2 shortcut now only fires when the command does NOT chain into
  a tfy apply/deploy or REST API call, so inline secrets in heredoc
  deploy pipelines are still scanned (Thread 13)

- post-deploy-monitor.sh: bridge CLAUDE_PLUGIN_OPTION_TFY_BASE_URL and
  CLAUDE_PLUGIN_OPTION_TFY_API_KEY from plugin userConfig. Each hook
  runs in a separate shell process so session-start.sh exports do not
  persist; without this the monitor silently exits when credentials
  come from userConfig (Thread 14)

- post-deploy-monitor.sh: use jq --arg for all JSON writes
  (deployments.jsonl and last-deploy.json) so YAML-quoted app names
  (e.g. name: "my-app") do not produce malformed JSON that breaks the
  stop-review-gate's jq parsing. Also strip surrounding YAML quotes
  from app_name at extraction time (Thread 15)

https://claude.ai/code/session_01PkggKq8diGz8zkGEQByero

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect deploy monitoring and pre-execution secret blocking hooks; regressions could cause missed scans, malformed state, or monitor failures/timeouts during deploys.
> 
> **Overview**
> Improves deploy monitoring reliability by **extending the PostToolUse hook timeout to 3600s** and bridging `CLAUDE_PLUGIN_OPTION_*` userConfig credentials into `post-deploy-monitor.sh` so monitoring works when env exports don’t persist across hooks.
> 
> Hardens state recording in `post-deploy-monitor.sh` by stripping YAML quotes from extracted `name:` values and switching JSON writes to `jq --arg*` to avoid malformed JSON that can break downstream `jq` parsing.
> 
> Fixes a secret-scan allowlist bypass in `pre-tool-secret-scan.sh` so “read-only” commands only skip scanning when they *don’t* chain into `tfy apply/deploy` or relevant REST API deploy calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e22ed429c0194c84e8200849f3b39d6f744718f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->