### PR TITLE
chore: gitignore .claude/ worktree directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 .DS_Store
+.claude/


### PR DESCRIPTION
## Summary
- Adds `.claude/` to `.gitignore` to prevent temporary Claude Code worktrees from being tracked
- Cleaned up a stale 4.4MB worktree (`great-jepsen`) that was left behind

## Test plan
- [x] `shellcheck` passes
- [x] `validate-skills.sh` passes
- [x] No other changes needed — full codebase scan confirmed no dead code or bloat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a gitignore-only change with no runtime or logic impact.
> 
> **Overview**
> Updates `.gitignore` to ignore the `.claude/` directory, preventing temporary Claude Code worktrees from being committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdd8e97890f0fd0cd7941055c2504f2317369c21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->