### PR TITLE
fix: align API endpoints with actual public OpenAPI spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 .DS_Store
+.claude/

--- a/skills/_shared/references/api-endpoints.md
+++ b/skills/_shared/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -43,7 +43,7 @@ tfy_roles_list()
 TFY_API_SH=~/.claude/skills/truefoundry-access-control/scripts/tfy-api.sh
 
 # List all roles
-$TFY_API_SH GET /api/svc/v1/roles
+$TFY_API_SH GET /api/svc/v1/role/list
 ```
 
 ### Presenting Roles
@@ -70,7 +70,7 @@ tfy_roles_create(payload={"name": "custom-deployer", "displayName": "Custom Depl
 #### Via Direct API
 
 ```bash
-$TFY_API_SH POST /api/svc/v1/roles '{"name":"custom-deployer","displayName":"Custom Deployer","description":"Can deploy apps","resourceType":"workspace","permissions":["deploy:create","deploy:read"]}'
+$TFY_API_SH PUT /api/svc/v1/role '{"name":"custom-deployer","displayName":"Custom Deployer","description":"Can deploy apps","resourceType":"workspace","permissions":["deploy:create","deploy:read"]}'
 ```
 
 ### Delete Role
@@ -86,7 +86,7 @@ tfy_roles_delete(id="ROLE_ID")
 #### Via Direct API
 
 ```bash
-$TFY_API_SH DELETE /api/svc/v1/roles/ROLE_ID
+$TFY_API_SH DELETE /api/svc/v1/role/ROLE_ID
 ```
 
 ## Teams
@@ -105,8 +105,8 @@ tfy_teams_list(team_id="TEAM_ID")  # get specific team
 #### Via Direct API
 
 ```bash
-# List all teams
-$TFY_API_SH GET /api/svc/v1/teams
+# List teams for the current user
+$TFY_API_SH GET /api/svc/v1/teams/user
 
 # Get a specific team
 $TFY_API_SH GET /api/svc/v1/teams/TEAM_ID
@@ -135,7 +135,7 @@ tfy_teams_create(payload={"name": "platform-team", "description": "Platform engi
 #### Via Direct API
 
 ```bash
-$TFY_API_SH POST /api/svc/v1/teams '{"name":"platform-team","description":"Platform engineering team"}'
+$TFY_API_SH PUT /api/svc/v1/teams '{"name":"platform-team","description":"Platform engineering team"}'
 ```
 
 ### Delete Team
@@ -154,44 +154,11 @@ tfy_teams_delete(id="TEAM_ID")
 $TFY_API_SH DELETE /api/svc/v1/teams/TEAM_ID
 ```
 
-### Add Member to Team
-
-#### Via Tool Call
-
-```
-tfy_teams_add_member(team_id="TEAM_ID", payload={"subject": "user:alice@company.com", "role": "member"})
-```
-
-**Note:** Requires human approval (HITL) via tool call.
-
-#### Via Direct API
-
-```bash
-$TFY_API_SH POST /api/svc/v1/teams/TEAM_ID/members '{"subject":"user:alice@company.com","role":"member"}'
-```
-
-### Remove Member from Team
-
-#### Via Tool Call
-
-```
-tfy_teams_remove_member(team_id="TEAM_ID", subject="user:alice@company.com")
-```
-
-**Note:** Requires human approval (HITL) via tool call.
-
-#### Via Direct API
-
-```bash
-$TFY_API_SH DELETE /api/svc/v1/teams/TEAM_ID/members/SUBJECT
-# Example SUBJECT: user:alice@company.com
-```
-
-## Collaborators
+## Authorization (Collaborators)
 
 > **Security:** Granting collaborator access is a privileged operation. Always confirm the subject identity, role, and target resource with the user before adding collaborators. Do not grant access based on unverified external identity references.
 
-Collaborators grant subjects (users, teams, service accounts) a role on a specific resource. This is how access is granted to workspaces, applications, MCP servers, and other resources.
+Authorization endpoints manage who has access to resources. Subjects (users, teams, service accounts) are granted roles on specific resources (workspaces, applications, MCP servers, etc.).
 
 ### Subject Format
 
@@ -217,21 +184,21 @@ tfy_collaborators_list(resource_type="workspace", resource_id="RESOURCE_ID")
 
 ```bash
 # List collaborators on a workspace
-$TFY_API_SH GET '/api/svc/v1/collaborators?resourceType=workspace&resourceId=RESOURCE_ID'
+$TFY_API_SH GET /api/svc/v1/authorize/workspace/RESOURCE_ID
 
 # List collaborators on an MCP server
-$TFY_API_SH GET '/api/svc/v1/collaborators?resourceType=mcp-server&resourceId=RESOURCE_ID'
+$TFY_API_SH GET /api/svc/v1/authorize/mcp-server/RESOURCE_ID
 ```
 
 ### Presenting Collaborators
 
 ```
 Collaborators on workspace "prod-workspace":
-| Subject                   | Role             | ID       |
-|---------------------------|------------------|----------|
-| user:alice@company.com    | workspace-admin  | collab-1 |
-| team:platform-team        | workspace-member | collab-2 |
-| serviceaccount:ci-bot     | workspace-member | collab-3 |
+| Subject                   | Role             |
+|---------------------------|------------------|
+| user:alice@company.com    | workspace-admin  |
+| team:platform-team        | workspace-member |
+| serviceaccount:ci-bot     | workspace-member |
 ```
 
 ### Add Collaborator
@@ -247,7 +214,23 @@ tfy_collaborators_create(payload={"resourceType": "workspace", "resourceId": "RE
 #### Via Direct API
 
 ```bash
-$TFY_API_SH POST /api/svc/v1/collaborators '{"resourceType":"workspace","resourceId":"RESOURCE_ID","subject":"user:alice@company.com","roleId":"ROLE_ID"}'
+$TFY_API_SH POST /api/svc/v1/authorize/workspace/RESOURCE_ID '{"subject":"user:alice@company.com","roleId":"ROLE_ID"}'
+```
+
+### Update Collaborator Role
+
+#### Via Tool Call
+
+```
+tfy_collaborators_update(payload={"resourceType": "workspace", "resourceId": "RESOURCE_ID", "subject": "user:alice@company.com", "roleId": "NEW_ROLE_ID"})
+```
+
+**Note:** Requires human approval (HITL) via tool call.
+
+#### Via Direct API
+
+```bash
+$TFY_API_SH PUT /api/svc/v1/authorize/workspace/RESOURCE_ID '{"subject":"user:alice@company.com","roleId":"NEW_ROLE_ID"}'
 ```
 
 ### Remove Collaborator
@@ -263,7 +246,14 @@ tfy_collaborators_delete(payload={"resourceType": "workspace", "resourceId": "RE
 #### Via Direct API
 
 ```bash
-$TFY_API_SH DELETE /api/svc/v1/collaborators '{"resourceType":"workspace","resourceId":"RESOURCE_ID","subject":"user:alice@company.com"}'
+$TFY_API_SH DELETE /api/svc/v1/authorize/workspace/RESOURCE_ID '{"subject":"user:alice@company.com"}'
+```
+
+### Check Access
+
+```bash
+# Check if a user has access to a resource
+$TFY_API_SH POST /api/svc/v1/authorize/check-access '{"resourceType":"workspace","resourceId":"RESOURCE_ID","subject":"user:alice@company.com","action":"deploy:create"}'
 ```
 
 ## Common Workflows
@@ -275,27 +265,23 @@ $TFY_API_SH DELETE /api/svc/v1/collaborators '{"resourceType":"workspace","resou
 
 ```bash
 # 1. Find the role ID
-$TFY_API_SH GET /api/svc/v1/roles
+$TFY_API_SH GET /api/svc/v1/role/list
 
 # 2. Add collaborator
-$TFY_API_SH POST /api/svc/v1/collaborators '{"resourceType":"workspace","resourceId":"WORKSPACE_ID","subject":"user:alice@company.com","roleId":"ROLE_ID"}'
+$TFY_API_SH POST /api/svc/v1/authorize/workspace/WORKSPACE_ID '{"subject":"user:alice@company.com","roleId":"ROLE_ID"}'
 ```
 
 ### Create a Team and Grant Access
 
 1. Create the team
-2. Add members to the team
-3. Add the team as a collaborator on the target resource
+2. Add the team as a collaborator on the target resource
 
 ```bash
 # 1. Create team
-$TFY_API_SH POST /api/svc/v1/teams '{"name":"ml-engineers","description":"ML engineering team"}'
+$TFY_API_SH PUT /api/svc/v1/teams '{"name":"ml-engineers","description":"ML engineering team"}'
 
-# 2. Add members (use team ID from response)
-$TFY_API_SH POST /api/svc/v1/teams/TEAM_ID/members '{"subject":"user:alice@company.com","role":"member"}'
-
-# 3. Grant team access to a workspace
-$TFY_API_SH POST /api/svc/v1/collaborators '{"resourceType":"workspace","resourceId":"WORKSPACE_ID","subject":"team:ml-engineers","roleId":"ROLE_ID"}'
+# 2. Grant team access to a workspace (use team slug as subject)
+$TFY_API_SH POST /api/svc/v1/authorize/workspace/WORKSPACE_ID '{"subject":"team:ml-engineers","roleId":"ROLE_ID"}'
 ```
 
 ### Audit Access on a Resource
@@ -303,7 +289,7 @@ $TFY_API_SH POST /api/svc/v1/collaborators '{"resourceType":"workspace","resourc
 List all collaborators to see who has access and with what role:
 
 ```bash
-$TFY_API_SH GET '/api/svc/v1/collaborators?resourceType=workspace&resourceId=WORKSPACE_ID'
+$TFY_API_SH GET /api/svc/v1/authorize/workspace/WORKSPACE_ID
 ```
 
 </instructions>

--- a/skills/access-control/references/api-endpoints.md
+++ b/skills/access-control/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/access-tokens/references/api-endpoints.md
+++ b/skills/access-tokens/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/applications/references/api-endpoints.md
+++ b/skills/applications/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/deploy/references/api-endpoints.md
+++ b/skills/deploy/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/docs/references/api-endpoints.md
+++ b/skills/docs/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/gitops/references/api-endpoints.md
+++ b/skills/gitops/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/helm/references/api-endpoints.md
+++ b/skills/helm/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/jobs/references/api-endpoints.md
+++ b/skills/jobs/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/llm-deploy/references/api-endpoints.md
+++ b/skills/llm-deploy/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/logs/references/api-endpoints.md
+++ b/skills/logs/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/ml-repos/references/api-endpoints.md
+++ b/skills/ml-repos/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/monitor/references/api-endpoints.md
+++ b/skills/monitor/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/notebooks/references/api-endpoints.md
+++ b/skills/notebooks/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/onboarding/references/api-endpoints.md
+++ b/skills/onboarding/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/secrets/references/api-endpoints.md
+++ b/skills/secrets/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/service-test/references/api-endpoints.md
+++ b/skills/service-test/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/ssh-server/references/api-endpoints.md
+++ b/skills/ssh-server/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/status/references/api-endpoints.md
+++ b/skills/status/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/tracing/SKILL.md
+++ b/skills/tracing/SKILL.md
@@ -44,7 +44,7 @@ tfy_tracing_list_projects()
 TFY_API_SH=~/.claude/skills/truefoundry-tracing/scripts/tfy-api.sh
 
 # List tracing projects
-$TFY_API_SH GET /api/ml/v1/tracing-projects
+$TFY_API_SH GET /api/svc/v1/tracing-projects
 ```
 
 ### Create a New Project
@@ -58,8 +58,8 @@ tfy_tracing_create_project(name="my-tracing-project")
 
 #### Via Direct API
 ```bash
-# Create tracing project
-$TFY_API_SH POST /api/ml/v1/tracing-projects '{"name": "my-tracing-project"}'
+# Create or update tracing project
+$TFY_API_SH PUT /api/svc/v1/tracing-projects '{"name": "my-tracing-project"}'
 ```
 
 Save the returned project `id` for the next step.
@@ -75,11 +75,9 @@ tfy_tracing_create_application(project_id="PROJECT_ID", name="my-app")
 
 #### Via Direct API
 ```bash
-# Create application under project
-$TFY_API_SH POST /api/ml/v1/tracing-projects/PROJECT_ID/applications '{"name": "my-app"}'
+# Create tracing application
+$TFY_API_SH POST /api/svc/v1/tracing-applications '{"name": "my-app", "tracingProjectId": "PROJECT_ID"}'
 ```
-
-> **Fallback**: If any of these API endpoints return 404, the tracing API may have changed. Direct the user to create the tracing project via the TrueFoundry UI at `$TFY_BASE_URL` → Tracing section, then return here with the project FQN.
 
 ## Step 3: Detect Application Type
 

--- a/skills/tracing/references/api-endpoints.md
+++ b/skills/tracing/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/volumes/references/api-endpoints.md
+++ b/skills/volumes/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/workflows/references/api-endpoints.md
+++ b/skills/workflows/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |

--- a/skills/workspaces/references/api-endpoints.md
+++ b/skills/workspaces/references/api-endpoints.md
@@ -52,8 +52,11 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/svc/v1/jobs/trigger` | Trigger a job run (body: applicationId) |
+| POST | `/api/svc/v1/jobs/terminate` | Terminate a running job |
 | GET | `/api/svc/v1/jobs/{jobId}/runs` | List job runs (query: searchPrefix, sortBy) |
-| GET | `/api/svc/v1/jobs/{jobId}/runs/{runName}` | Get a specific job run |
+| GET | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Get a specific job run |
+| DELETE | `/api/svc/v1/jobs/{jobId}/runs/{jobRunName}` | Delete a job run |
+| POST | `/api/svc/v1/jobs/{jobId}/command` | Send command to a job |
 
 ## Logs
 | Method | Path | Description |
@@ -75,11 +78,13 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Tracing
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/ml/v1/tracing-projects` | List tracing projects |
-| POST | `/api/ml/v1/tracing-projects` | Create tracing project (body: name) |
-| GET | `/api/ml/v1/tracing-projects/{id}` | Get tracing project |
-| GET | `/api/ml/v1/tracing-projects/{id}/applications` | List applications in project |
-| POST | `/api/ml/v1/tracing-projects/{id}/applications` | Create application in project (body: name) |
+| GET | `/api/svc/v1/tracing-projects` | List tracing projects |
+| PUT | `/api/svc/v1/tracing-projects` | Create or update tracing project (body: name) |
+| GET | `/api/svc/v1/tracing-projects/{id}` | Get tracing project by ID |
+| DELETE | `/api/svc/v1/tracing-projects/{id}` | Delete tracing project |
+| GET | `/api/svc/v1/tracing-applications` | List tracing applications |
+| POST | `/api/svc/v1/tracing-applications` | Create tracing application (body: name, tracingProjectId) |
+| DELETE | `/api/svc/v1/tracing-applications/{id}` | Delete tracing application |
 
 ## ML Repos
 | Method | Path | Description |
@@ -115,27 +120,40 @@ Auth: `Authorization: Bearer $TFY_API_KEY` (read from env; never hardcode or pri
 ## Roles
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/roles` | List roles (query: resourceType) |
-| POST | `/api/svc/v1/roles` | Create a role (body: name, displayName, description, resourceType, permissions) |
-| GET | `/api/svc/v1/roles/{id}` | Get role by ID |
-| DELETE | `/api/svc/v1/roles/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/list` | List all roles |
+| GET | `/api/svc/v1/role` | Get roles (query: resourceType) |
+| PUT | `/api/svc/v1/role` | Create or update a role (body: name, displayName, description, resourceType, permissions) |
+| DELETE | `/api/svc/v1/role/{id}` | Delete a role |
+| GET | `/api/svc/v1/role/actions` | Get available actions for a resource type (query: resourceType) |
 
 ## Teams
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/teams` | List teams |
-| POST | `/api/svc/v1/teams` | Create a team (body: name, description) |
+| PUT | `/api/svc/v1/teams` | Create or update a team (body: name, description) |
 | GET | `/api/svc/v1/teams/{id}` | Get team by ID |
 | DELETE | `/api/svc/v1/teams/{id}` | Delete a team |
-| POST | `/api/svc/v1/teams/{id}/members` | Add member to team (body: subject, role) |
-| DELETE | `/api/svc/v1/teams/{id}/members/{subject}` | Remove member from team |
+| GET | `/api/svc/v1/teams/user` | List teams for the current user |
+| GET | `/api/svc/v1/teams/{id}/permissions` | Get team permissions |
 
-## Collaborators
+## Authorization (Collaborators)
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/api/svc/v1/collaborators` | List collaborators on a resource (query: resourceType, resourceId) |
-| POST | `/api/svc/v1/collaborators` | Add collaborator to a resource (body: resourceType, resourceId, subject, roleId) |
-| DELETE | `/api/svc/v1/collaborators` | Remove collaborator from a resource (body: resourceType, resourceId, subject) |
+| GET | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | List authorized users/collaborators on a resource |
+| POST | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Add collaborator to a resource (body: subject, roleId) |
+| PUT | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Update collaborator role on a resource |
+| DELETE | `/api/svc/v1/authorize/{resourceType}/{resourceId}` | Remove collaborator from a resource (body: subject) |
+| POST | `/api/svc/v1/authorize/check-access` | Check if a user has access to a resource |
+| GET | `/api/svc/v1/authorize/permissions` | Get permissions for a resource |
+
+## Role Bindings
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/api/svc/v1/role-bindings` | Create or update a role binding |
+| GET | `/api/svc/v1/role-bindings` | List all role bindings |
+| GET | `/api/svc/v1/role-bindings/{id}` | Get role binding by ID |
+| DELETE | `/api/svc/v1/role-bindings/{id}` | Delete role binding by ID |
+| GET | `/api/svc/v1/role-bindings/exists` | Check if a role binding exists |
+| POST | `/api/svc/v1/role-bindings/inline` | Create inline role bindings |
 
 ## Guardrails
 | Method | Path | Description |


### PR DESCRIPTION
## Summary

- Audited all 542 API paths from the live OpenAPI spec (`/api/svc/docs-json`) against every endpoint referenced in our 22 skills
- Fixed 6 categories of non-existent endpoints that were causing 404s for external users (reported by CCI-Atlanta team)
- All endpoint references now match the actual public API — no internal `/v1/x/` paths used

## What Changed

| Category | Before (broken) | After (correct) |
|----------|-----------------|-----------------|
| **Roles** | `/api/svc/v1/roles` (GET/POST) | `/api/svc/v1/role/list` (GET), `/api/svc/v1/role` (PUT) |
| **Teams** | `GET /api/svc/v1/teams`, `POST .../teams/{id}/members` | `PUT /api/svc/v1/teams`, removed non-existent members endpoints |
| **Collaborators** | `/api/svc/v1/collaborators` (non-existent) | `/api/svc/v1/authorize/{resourceType}/{resourceId}` |
| **Jobs** | `{runName}` param | `{jobRunName}`, added terminate/command |
| **Tracing** | `/api/ml/v1/tracing-projects` (POST) | `/api/svc/v1/tracing-projects` (PUT), `/api/svc/v1/tracing-applications` |
| **Role Bindings** | (missing) | New section with `/api/svc/v1/role-bindings` endpoints |

## Files Changed

- `skills/_shared/references/api-endpoints.md` — canonical endpoint reference
- `skills/access-control/SKILL.md` — roles, teams, collaborators skill
- `skills/tracing/SKILL.md` — tracing project setup
- 22x `skills/*/references/api-endpoints.md` — synced copies

## Test plan

- [x] `./scripts/validate-skills.sh` passes
- [x] `./scripts/validate-skill-security.sh` passes
- [x] `./scripts/test-tfy-api.sh` passes
- [x] `shellcheck` passes on all scripts
- [x] No stale references to old endpoints (`/v1/collaborators`, `/v1/roles`, `/api/ml/v1/tracing-projects`, `{runName}`, `teams/{id}/members`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that change many endpoint references; risk is mainly that clients/skills could still point to incorrect paths if any mapping is wrong.
> 
> **Overview**
> **Aligns all skill API endpoint references with the public `/api/svc/v1` OpenAPI spec** to avoid 404s.
> 
> Updates roles/teams/collaborators docs to use the new role and authorization routes (e.g., `GET /api/svc/v1/role/list`, `PUT /api/svc/v1/role`, and `.../authorize/{resourceType}/{resourceId}`), removes the non-existent team member endpoints, and adds role binding endpoints.
> 
> Refreshes job and tracing references (adds job `terminate`/`command`, renames `{runName}` to `{jobRunName}`, and switches tracing project/application APIs from `/api/ml/v1` to `/api/svc/v1`). Also ignores `.claude/` in `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61baccb8b9004b036cde8be8e6579aec22a032a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->