### PR TITLE
docs: fix stale counts and descriptions across docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,11 @@ A collection of 22 AI coding-agent skill definitions (markdown + shell scripts) 
 
 This is a **content/tooling repository** -- there are no application servers, databases, or Docker containers. The codebase consists of:
 
-- **skills/** -- 21 skill directories (e.g. `deploy`, `helm`, `llm-deploy`, `logs`, `status`, etc.) each containing a `SKILL.md` frontmatter file, plus `_shared/` with canonical scripts and references synced to all skills.
+- **skills/** -- 22 skill directories (e.g. `deploy`, `helm`, `llm-deploy`, `logs`, `status`, etc.) each containing a `SKILL.md` frontmatter file, plus `_shared/` with canonical scripts and references synced to all skills.
 - **scripts/** -- development and CI tooling (validation, sync, install, tests).
-- **hooks/** -- git pre-push hook and Claude Code auto-approve hook.
+- **hooks/** -- Claude Code hook definitions (`hooks.json`), auto-approve hook, and git pre-push hook.
+- **plugin-scripts/** -- hook implementations (session-start, block-delete, secret-scan, deploy-monitor, verification gate).
+- **agents/** -- specialized agent definitions (deploy-orchestrator, troubleshoot).
 
 ### Key Commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,13 +36,20 @@ cd tfy-deploy-skills
 
 3. **Use CLI-first instructions with Direct API fallback.** Every skill should work when CLI is available, with API fallback when needed.
 
-4. **Reference shared files** instead of duplicating content:
+4. **Reference shared files** instead of duplicating content (13 shared references in `skills/_shared/references/`):
+   - `references/api-endpoints.md` — full API endpoint reference
    - `references/prerequisites.md` — credential checks, env vars
    - `references/tfy-api-setup.md` — agent path table for tfy-api.sh
+   - `references/cli-fallback.md` — CLI-first with API fallback patterns
    - `references/gpu-reference.md` — GPU types and sizing
    - `references/cluster-discovery.md` — cluster ID, base domains, storage classes
    - `references/health-probes.md` — probe configuration
    - `references/resource-estimation.md` — CPU/memory/replica sizing
+   - `references/manifest-schema.md` — YAML manifest field reference
+   - `references/manifest-defaults.md` — sensible defaults for manifests
+   - `references/rest-api-manifest.md` — deploying via REST API
+   - `references/container-versions.md` — container version reference
+   - `references/intent-clarification.md` — disambiguation templates
 
 5. **Reference the `status` skill** for preflight checks.
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ tfy-deploy-skills/
   skills/
     _shared/               # Canonical copies of shared scripts and references
       scripts/             # tfy-api.sh, tfy-version.sh
-      references/          # 12 shared reference docs
+      references/          # 13 shared reference docs
     deploy/SKILL.md        # One directory per skill
     monitor/SKILL.md
     ...


### PR DESCRIPTION
## Summary

Follow-up to #15 (API endpoint audit). Fixes stale metadata across docs files:

- **AGENTS.md**: "21 skill directories" → 22, updated `hooks/` description to reflect plugin architecture (hooks.json, plugin-scripts/, agents/)
- **README.md**: "12 shared reference docs" → 13 in architecture tree
- **CONTRIBUTING.md**: Listed all 13 shared references (was only showing 6 of 13)

## Test plan

- [x] `./scripts/validate-skills.sh` passes
- [x] `./scripts/validate-skill-security.sh` passes
- [x] No stale counts remain (`grep -rn "21 skill\|12 shared" *.md` returns nothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that correct counts and descriptions of repository structure; no code or runtime behavior changes.
> 
> **Overview**
> Fixes stale documentation metadata by updating the repo overview to reflect **22 skills** and clarifying the `hooks/`, `plugin-scripts/`, and `agents/` structure.
> 
> Updates contributor guidance to enumerate all **13 shared reference docs**, and adjusts the README architecture tree to reflect the same reference count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0a4fd847d9712409bfec0c3552aada88cf767f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->