### PR TITLE
fix(plugin): add type/title to userConfig and use explicit agents array

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -18,15 +18,22 @@
     "gpu"
   ],
   "skills": "./skills/",
-  "agents": "./agents/",
+  "agents": [
+    "./agents/deploy-orchestrator.md",
+    "./agents/troubleshoot.md"
+  ],
   "hooks": "./hooks/hooks.json",
   "userConfig": {
     "TFY_BASE_URL": {
+      "title": "TrueFoundry Base URL",
       "description": "TrueFoundry platform URL (e.g., https://your-org.truefoundry.cloud)",
+      "type": "string",
       "sensitive": false
     },
     "TFY_API_KEY": {
+      "title": "TrueFoundry API Key",
       "description": "TrueFoundry API key for authentication",
+      "type": "string",
       "sensitive": true
     }
   }


### PR DESCRIPTION
- Add required `type: "string"` and `title` fields to TFY_BASE_URL and TFY_API_KEY userConfig entries
- Change `agents` from directory path string to explicit array of file paths

https://claude.ai/code/session_01W47YWvNrfwXKrQUjEodhbH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only changes that affect plugin metadata/validation and agent discovery, with no runtime logic or data flow changes.
> 
> **Overview**
> Updates `.claude-plugin/plugin.json` to enumerate `agents` as an explicit list of markdown files instead of a directory path.
> 
> Adds `title` and `type: "string"` to the `TFY_BASE_URL` and `TFY_API_KEY` entries under `userConfig` to better define/validate required user inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2c84a19b661559bd38737f48d361fb60d4bd89f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->