### PR TITLE
fix: enforce plugin auth flow over MCP tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ Skills: truefoundry-deploy, truefoundry-secrets, truefoundry-workspaces, truefou
 4. **NEVER claim deployment is complete** until the PostToolUse hook confirms terminal state. If the hook hasn't reported back, keep waiting.
 5. **Always set `TFY_HOST`** before any tfy CLI command: `export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"`
 6. **NEVER delete any resource.** If the user asks to delete a deployment, service, application, workspace, volume, secret, or any other resource, do NOT call any DELETE API. Instead, provide manual instructions: "To delete [resource], go to your TrueFoundry dashboard at $TFY_BASE_URL, navigate to [specific path], and delete it from the UI." This is a safety measure to prevent accidental deletions.
+7. **NEVER use MCP tools** (tfy-cursor, tam-mcp, etc.) for TrueFoundry operations. All authentication and API access must go through this plugin's scripts (`tfy-api.sh`) and the `tfy` CLI. If credentials are missing, ask the user to set `TFY_BASE_URL` and `TFY_API_KEY` — do not trigger MCP authentication flows.
 
 ### DEPLOYMENT WORKFLOW (follow in order)
 
@@ -162,6 +163,7 @@ Skills: truefoundry-logs, truefoundry-monitor, truefoundry-applications, truefou
 ### HARD RULES (NEVER VIOLATE)
 
 1. **NEVER delete any resource.** If the user asks to delete a deployment, service, application, workspace, volume, secret, or any other resource, do NOT call any DELETE API. Instead, provide manual instructions: "To delete [resource], go to your TrueFoundry dashboard at $TFY_BASE_URL, navigate to [specific path], and delete it from the UI." This is a safety measure to prevent accidental deletions.
+2. **NEVER use MCP tools** (tfy-cursor, tam-mcp, etc.) for TrueFoundry operations. All authentication and API access must go through this plugin's scripts (`tfy-api.sh`) and the `tfy` CLI. If credentials are missing, ask the user to set `TFY_BASE_URL` and `TFY_API_KEY` — do not trigger MCP authentication flows.
 
 ### WORKFLOW
 

--- a/agents/deploy-orchestrator.md
+++ b/agents/deploy-orchestrator.md
@@ -16,6 +16,7 @@ You are the TrueFoundry Deploy Orchestrator. You handle the full deployment life
 4. **NEVER claim deployment is complete** until the PostToolUse hook confirms terminal state. If the hook hasn't reported back, keep waiting.
 5. **Always set `TFY_HOST`** before any tfy CLI command: `export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"`
 6. **NEVER delete any resource.** If the user asks to delete a deployment, service, application, workspace, volume, secret, or any other resource, do NOT call any DELETE API. Instead, provide manual instructions: "To delete [resource], go to your TrueFoundry dashboard at $TFY_BASE_URL, navigate to [specific path], and delete it from the UI." This is a safety measure to prevent accidental deletions.
+7. **NEVER use MCP tools** (tfy-cursor, tam-mcp, etc.) for TrueFoundry operations. All authentication and API access must go through this plugin's scripts (`tfy-api.sh`) and the `tfy` CLI. If credentials are missing, ask the user to set `TFY_BASE_URL` and `TFY_API_KEY` — do not trigger MCP authentication flows.
 
 ## DEPLOYMENT WORKFLOW (follow in order)
 

--- a/agents/troubleshoot.md
+++ b/agents/troubleshoot.md
@@ -11,6 +11,7 @@ You are the TrueFoundry Troubleshoot Agent. You diagnose deployment failures and
 ## HARD RULES (NEVER VIOLATE)
 
 1. **NEVER delete any resource.** If the user asks to delete a deployment, service, application, workspace, volume, secret, or any other resource, do NOT call any DELETE API. Instead, provide manual instructions: "To delete [resource], go to your TrueFoundry dashboard at $TFY_BASE_URL, navigate to [specific path], and delete it from the UI." This is a safety measure to prevent accidental deletions.
+2. **NEVER use MCP tools** (tfy-cursor, tam-mcp, etc.) for TrueFoundry operations. All authentication and API access must go through this plugin's scripts (`tfy-api.sh`) and the `tfy` CLI. If credentials are missing, ask the user to set `TFY_BASE_URL` and `TFY_API_KEY` — do not trigger MCP authentication flows.
 
 ## WORKFLOW
 

--- a/plugin-scripts/session-start.sh
+++ b/plugin-scripts/session-start.sh
@@ -266,3 +266,17 @@ if [[ "$conn_status" = "endpoint_not_found" ]]; then
   echo ""
   echo "Verify TFY_BASE_URL is correct (e.g., https://your-org.truefoundry.cloud)"
 fi
+
+# --- Anti-MCP directive ---
+# This instruction is injected into the conversation context to prevent Claude
+# from using MCP tools (tfy-cursor, etc.) instead of the plugin's own workflow.
+echo ""
+echo "IMPORTANT: This plugin handles ALL TrueFoundry authentication and API access."
+echo "Do NOT use MCP tools (tfy-cursor, tam-mcp, etc.) for TrueFoundry operations."
+echo "Do NOT trigger MCP authentication flows — they conflict with the plugin workflow."
+echo "Instead, use the plugin's skills and scripts:"
+echo "  - tfy-api.sh for authenticated REST API calls"
+echo "  - tfy CLI for deployments (tfy apply, tfy deploy)"
+echo "  - truefoundry-onboarding skill for first-time setup"
+echo "If credentials are missing, ask the user to set TFY_BASE_URL and TFY_API_KEY"
+echo "via environment variables or a .env file. Never redirect to MCP auth flows."


### PR DESCRIPTION
## Summary
- When users have TrueFoundry MCP servers (e.g. `tfy-cursor`) configured alongside this plugin, Claude would use MCP OAuth flows instead of the plugin's own credential workflow
- Adds instruction-based enforcement (no hard blocks) so the plugin flow is always preferred
- `session-start.sh` now outputs an anti-MCP directive into every session context
- Agent hard rules in `deploy-orchestrator`, `troubleshoot`, and `AGENTS.md` now include "never use MCP tools for TrueFoundry operations"

## Why instruction-based, not hook-based
A `PreToolUse` hook that hard-blocks MCP tools was considered but rejected — it's heavy-handed and would need removal if/when MCP is adopted. Instructions alone are sufficient (confirmed by manual testing).

## Test plan
- [ ] Install plugin in a Claude Code session that also has `tfy-cursor` MCP configured
- [ ] Ask Claude to deploy — verify it follows plugin flow (credential check, CLI, tfy-api.sh) instead of triggering MCP auth
- [ ] Verify `shellcheck` and `validate-skills.sh` pass
- [ ] Verify session-start output includes the anti-MCP directive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/runtime messaging change that only adds guidance text; no changes to API calls or deployment logic, but it may affect user/agent behavior by steering away from MCP flows.
> 
> **Overview**
> Prevents sessions from drifting into MCP-based TrueFoundry auth by **explicitly instructing agents to avoid MCP tools** and stick to the plugin workflow.
> 
> Adds a new hard rule in `AGENTS.md`, `agents/deploy-orchestrator.md`, and `agents/troubleshoot.md` to never use MCP tools (e.g., `tfy-cursor`). `plugin-scripts/session-start.sh` now prints an **anti-MCP directive** into every session context, directing authentication and API access through `tfy-api.sh`, the `tfy` CLI, and onboarding guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e895d8ef5953b887ab47ae7c2a68fbb3153a2098. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->