### PR TITLE
fix(plugin): remove duplicate skills declaration from plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -17,7 +17,6 @@
     "llm",
     "gpu"
   ],
-  "skills": "./skills/",
   "agents": [
     "./agents/deploy-orchestrator.md",
     "./agents/troubleshoot.md"


### PR DESCRIPTION
## Summary

- `plugin.json` and `marketplace.json` both declared `skills` components, causing Claude Code to throw a "conflicting manifests" error on `/reload-plugins`
- Removed `"skills": "./skills/"` from `plugin.json` — skills are already enumerated authoritatively in `marketplace.json`
- All skill validation and security checks pass

## Test plan

- [ ] Run `/plugin uninstall truefoundry@truefoundry-deploy-skills`
- [ ] Run `/plugin marketplace add truefoundry/tfy-deploy-skills`
- [ ] Run `/plugin install truefoundry@truefoundry-deploy-skills`
- [ ] Run `/reload-plugins` — verify no "conflicting manifests" error
- [ ] Run `/doctor` — verify no plugin errors

https://claude.ai/code/session_01UsQ9FD3Epf4sTjwrBv34Nw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk manifest-only change that removes a redundant `skills` entry to prevent plugin manifest conflicts during reload; no runtime logic changes.
> 
> **Overview**
> Resolves a Claude plugin manifest conflict by removing the `"skills": "./skills/"` declaration from `.claude-plugin/plugin.json`, leaving skills to be defined via the marketplace manifest instead.
> 
> This is a configuration-only change intended to stop `/reload-plugins` from failing due to duplicate/competing `skills` definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 773fecd0b5e6224b3253498f11634c716efcf6e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->